### PR TITLE
Add API 24-25 support. Add an example. Add API 26-27 example

### DIFF
--- a/DynamicLibrary.cpp
+++ b/DynamicLibrary.cpp
@@ -16,7 +16,7 @@ DynamicLibrary::~DynamicLibrary()
 
 void *DynamicLibrary::getFunctionPtr(const char *name) const
 {
-    auto ret = (void *)dlsym(libHandle, name);
+    auto ret = (void *) dlsym(libHandle, name);
     if (ret == nullptr) {
         std::cerr << "Failed to get function " << name << std::endl;
     }

--- a/DynamicLibrary.cpp
+++ b/DynamicLibrary.cpp
@@ -1,7 +1,7 @@
 #include "DynamicLibrary.h"
 
-#include <iostream>
 #include <dlfcn.h>
+#include <android/log.h>
 
 DynamicLibrary::DynamicLibrary(const char *fileName)
 {
@@ -18,7 +18,7 @@ void *DynamicLibrary::getFunctionPtr(const char *name) const
 {
     auto ret = (void *) dlsym(libHandle, name);
     if (ret == nullptr) {
-        std::cerr << "Failed to get function " << name << std::endl;
+        __android_log_print(ANDROID_LOG_ERROR, "GraphicBuffer", "Failed to get function %s", name);
     }
     return ret;
 }

--- a/DynamicLibrary.h
+++ b/DynamicLibrary.h
@@ -1,3 +1,8 @@
+/**
+ * @file DynamicLibrary.h
+ * @brief This class implements a C++ wrapper to load shared libraries (.so)
+ */
+
 #pragma once
 
 #include <exception>
@@ -9,6 +14,11 @@ public:
     DynamicLibrary(const char *fileName);
     ~DynamicLibrary();
 
+    /**
+     * @brief getFunctionPtr Resolve the symbol name
+     * @param name The symbol name to resolve
+     * @return The resolved function
+     */
     void *getFunctionPtr(const char *name) const;
 
     DynamicLibrary(const DynamicLibrary &) = delete;

--- a/GraphicBuffer.cpp
+++ b/GraphicBuffer.cpp
@@ -107,7 +107,7 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
     // See README of the repository to understand the issue with versions
 
     #if __ANDROID_API__ <= 23
-    #warning "Android API 23 or elss detected. Using OLD constructor style for GraphicBuffer"
+    #warning "Android API 23 or less detected. Using OLD constructor style for GraphicBuffer"
     setFuncPtr(functions.constructor, library, "_ZN7android13GraphicBufferC1Ejjij");
     #elif (__ANDROID_API__ >= 24) && (__ANDROID_API__ <= 25)
     #warning "Android API 24 or 25 detected. Using NEW constructor style for GraphicBuffer"

--- a/GraphicBuffer.cpp
+++ b/GraphicBuffer.cpp
@@ -26,23 +26,13 @@ void setFuncPtr (Func*& funcPtr, const DynamicLibrary& lib, const string& symnam
 #	warning "target CPU does not support ABI"
 #endif
 
-template <typename RT, typename T1, typename T2, typename T3, typename T4>
-RT* callConstructor4 (void (*fptr)(), void* memory, T1 param1, T2 param2, T3 param3, T4 param4)
+template <typename RT, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+RT* callConstructor7 (void (*fptr)(), void* memory, T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7)
 {
 #if defined(CPU_ARM)
     // C1 constructors return pointer
-    typedef RT* (*ABIFptr)(void*, T1, T2, T3, T4);
-    (void)((ABIFptr)fptr)(memory, param1, param2, param3, param4);
-    return reinterpret_cast<RT*>(memory);
-#elif defined(CPU_ARM_64)
-    // C1 constructors return void
-    typedef void (*ABIFptr)(void*, T1, T2, T3, T4);
-    ((ABIFptr)fptr)(memory, param1, param2, param3, param4);
-    return reinterpret_cast<RT*>(memory);
-#elif defined(CPU_X86) || defined(CPU_X86_64)
-    // ctor returns void
-    typedef void (*ABIFptr)(void*, T1, T2, T3, T4);
-    ((ABIFptr)fptr)(memory, param1, param2, param3, param4);
+    typedef RT* (*ABIFptr)(void*, T1, T2, T3, T4, T5, T6, T7);
+    (void)((ABIFptr)fptr)(memory, param1, param2, param3, param4, param5, param6, param7);
     return reinterpret_cast<RT*>(memory);
 #else
     return nullptr;
@@ -81,7 +71,7 @@ static android::android_native_base_t* getAndroidNativeBase (android::GraphicBuf
 GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format, uint32_t usage):
     library("libui.so")
 {
-    setFuncPtr(functions.constructor, library, "_ZN7android13GraphicBufferC1Ejjij");
+    setFuncPtr(functions.constructor, library, "_ZN7android13GraphicBufferC2EjjijjP13native_handleb");
     setFuncPtr(functions.destructor, library, "_ZN7android13GraphicBufferD1Ev");
     setFuncPtr(functions.getNativeBuffer, library, "_ZNK7android13GraphicBuffer15getNativeBufferEv");
     setFuncPtr(functions.lock, library, "_ZN7android13GraphicBuffer4lockEjPPv");
@@ -96,13 +86,17 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
     }
 
     try {
-        android::GraphicBuffer* const gb = callConstructor4<android::GraphicBuffer, uint32_t, uint32_t, PixelFormat, uint32_t>(
+        android::GraphicBuffer* const gb = callConstructor7<android::GraphicBuffer, uint32_t, uint32_t, PixelFormat, uint32_t,
+                uint32_t, void*, bool>(
                 functions.constructor,
                 memory,
                 width,
                 height,
                 format,
-                usage
+                usage,
+                    1,
+                    nullptr,
+                    false
                 );
         android::android_native_base_t* const base = getAndroidNativeBase(gb);
         status_t ctorStatus = functions.initCheck(gb);

--- a/GraphicBuffer.cpp
+++ b/GraphicBuffer.cpp
@@ -141,9 +141,9 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
     #warning "See README of the GraphicBuffer repository for more details"
     setFuncPtr(functions.constructor, library, "_ZN7android13GraphicBufferC1EjjijNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE");
     #elif __ANDROID_API__ >= 26
-        #error "You are trying to use GraphicBuffer hack for API 26 or higher. You can use the 'legal' HardwareBuffer instead, see README in the repository"
+        #warning "You are trying to use GraphicBuffer hack for API 26 or higher. You can use the 'legal' HardwareBuffer instead, see README in the repository"
     #else
-        #error "Invalid settings detected. Please set __ANDROID_API__ to a valid value"
+        #warning "Invalid settings detected. Please set __ANDROID_API__ to a valid value"
     #endif
     setFuncPtr(functions.destructor, library, "_ZN7android13GraphicBufferD1Ev");
     setFuncPtr(functions.getNativeBuffer, library, "_ZNK7android13GraphicBuffer15getNativeBufferEv");

--- a/GraphicBuffer.cpp
+++ b/GraphicBuffer.cpp
@@ -6,14 +6,17 @@
 
 using std::string;
 
+// Size of the system GraphicBuffer object
 const int GRAPHICBUFFER_SIZE = 1024;
 
+/// @brief Set function pointer to a symbol from .so file
 template<typename Func>
 void setFuncPtr (Func*& funcPtr, const DynamicLibrary& lib, const string& symname)
 {
     funcPtr = reinterpret_cast<Func*>(lib.getFunctionPtr(symname.c_str()));
 }
 
+// checking the CPU architecture
 #if defined(__aarch64__)
 #	define CPU_ARM_64
 #elif defined(__arm__) || defined(__ARM__) || defined(__ARM_NEON__) || defined(ARM_BUILD)
@@ -26,6 +29,13 @@ void setFuncPtr (Func*& funcPtr, const DynamicLibrary& lib, const string& symnam
 #	warning "target CPU does not support ABI"
 #endif
 
+/// @brief This function calls a constructor of a class with 4 arguments
+/// @param fptr The pointer to the constructor
+/// @param memory The address of the object
+/// @param param1 Parameter 1
+/// @param param1 Parameter 2
+/// @param param1 Parameter 3
+/// @param param1 Parameter 4
 template <typename RT, typename T1, typename T2, typename T3, typename T4>
 RT* callConstructor4 (void (*fptr)(), void* memory, T1 param1, T2 param2, T3 param3, T4 param4)
 {
@@ -49,6 +59,14 @@ RT* callConstructor4 (void (*fptr)(), void* memory, T1 param1, T2 param2, T3 par
 #endif
 }
 
+/// @brief This function calls a constructor of a class with 5 arguments
+/// @param fptr The pointer to the constructor
+/// @param memory The address of the object
+/// @param param1 Parameter 1
+/// @param param1 Parameter 2
+/// @param param1 Parameter 3
+/// @param param1 Parameter 4
+/// @param param1 Parameter 5
 template <typename RT, typename T1, typename T2, typename T3, typename T4, typename T5>
 RT* callConstructor5 (void (*fptr)(), void* memory, T1 param1, T2 param2, T3 param3, T4 param4, T5 param5)
 {
@@ -72,6 +90,9 @@ RT* callConstructor5 (void (*fptr)(), void* memory, T1 param1, T2 param2, T3 par
 #endif
 }
 
+/// @brief This function calls a destructor of a class
+/// @param fptr The pointer to the destructor
+/// @param obj The address of the object
 template <typename T>
 void callDestructor (void (*fptr)(), T* obj)
 {
@@ -90,12 +111,14 @@ void callDestructor (void (*fptr)(), T* obj)
 #endif
 }
 
+/// @brief Add bytes to the pointer
 template<typename T1, typename T2>
 T1* pointerToOffset (T2* ptr, size_t bytes)
 {
     return reinterpret_cast<T1*>((uint8_t *)ptr + bytes);
 }
 
+/// @brief This function returns the member of the system GraphicBuffer object which is the native base
 static android::android_native_base_t* getAndroidNativeBase (android::GraphicBuffer* gb)
 {
     return pointerToOffset<android::android_native_base_t>(gb, 2 * sizeof(void *));
@@ -105,6 +128,9 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
     library("libui.so")
 {
     // See README of the repository to understand the issue with versions
+    // also that document describes how to obtain symbol names for functions
+
+    // Setting up the function pointers from the .so file libui.so
 
     #if __ANDROID_API__ <= 23
     #warning "Android API 23 or less detected. Using OLD constructor style for GraphicBuffer"
@@ -116,6 +142,8 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
     setFuncPtr(functions.constructor, library, "_ZN7android13GraphicBufferC1EjjijNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE");
     #elif __ANDROID_API__ >= 26
         #error "You are trying to use GraphicBuffer hack for API 26 or higher. You can use the 'legal' HardwareBuffer instead, see README in the repository"
+    #else
+        #error "Invalid settings detected. Please set __ANDROID_API__ to a valid value"
     #endif
     setFuncPtr(functions.destructor, library, "_ZN7android13GraphicBufferD1Ev");
     setFuncPtr(functions.getNativeBuffer, library, "_ZNK7android13GraphicBuffer15getNativeBufferEv");
@@ -123,15 +151,17 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
     setFuncPtr(functions.unlock, library, "_ZN7android13GraphicBuffer6unlockEv");
     setFuncPtr(functions.initCheck, library, "_ZNK7android13GraphicBuffer9initCheckEv");
 
-    // allocate memory for GraphicBuffer object
+    // allocating memory for GraphicBuffer object
     void *const memory = malloc(GRAPHICBUFFER_SIZE);
     if (memory == nullptr) {
         std::cerr << "Could not alloc for GraphicBuffer" << std::endl;
         return;
     }
 
+    // trying to create a graphicbuffer object
     try {
-        #if (__ANDROID_API__ >= 23) && (__ANDROID_API__ <= 24)
+        // Calling the constructor
+        #if __ANDROID_API__ <= 23
         android::GraphicBuffer* const gb = callConstructor4<android::GraphicBuffer, uint32_t, uint32_t, PixelFormat, uint32_t>(
                 functions.constructor,
                 memory,
@@ -140,7 +170,7 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
                 format,
                 usage
                 );
-        #elif __ANDROID_API__ >= 26
+        #elif (__ANDROID_API__ >= 24) && (__ANDROID_API__ <= 25)
         // the name for the graphic buffer
         static std::string name = std::string("DirtyHackUser");
 
@@ -153,15 +183,20 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
                 usage,
                 &name
                 );
+        #else
+            android::GraphicBuffer* const gb = nullptr;
         #endif
 
+        // Obtaining the native base
         android::android_native_base_t* const base = getAndroidNativeBase(gb);
+
+        // checking the status of the object
         status_t ctorStatus = functions.initCheck(gb);
 
         if (ctorStatus) {
             // ctor failed
             callDestructor<android::GraphicBuffer>(functions.destructor, gb);
-            std::cerr << "GraphicBuffer ctor failed, initCheck returned "  << ctorStatus << std::endl;
+            std::cerr << "GraphicBuffer constructor failed, initCheck returned " << ctorStatus << std::endl;
         }
 
         // check object layout
@@ -173,9 +208,14 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
         if (base->version != expectedVersion)
             std::cerr << "GraphicBuffer version unexpected" << std::endl;
 
+        // reference count
         base->incRef(base);
+
+        // saving the pointer to the system GraphicBuffer
         impl = gb;
     } catch (...) {
+        // freeing memory on error
+        std::cerr << "GraphicBuffer constructor failed" << std::endl;
         free(memory);
         throw;
     }
@@ -207,5 +247,5 @@ ANativeWindowBuffer *GraphicBuffer::getNativeBuffer() const
 
 uint32_t GraphicBuffer::getStride() const
 {
-    return ((android::android_native_buffer_t*)getNativeBuffer())->stride;
+    return ((android::android_native_buffer_t*) getNativeBuffer())->stride;
 }

--- a/GraphicBuffer.cpp
+++ b/GraphicBuffer.cpp
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <cstdlib>
-#include <iostream>
+#include <android/log.h>
 
 using std::string;
 
@@ -154,7 +154,7 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
     // allocating memory for GraphicBuffer object
     void *const memory = malloc(GRAPHICBUFFER_SIZE);
     if (memory == nullptr) {
-        std::cerr << "Could not alloc for GraphicBuffer" << std::endl;
+        __android_log_print(ANDROID_LOG_ERROR, "GraphicBuffer", "Could not alloc for GraphicBuffer");
         return;
     }
 
@@ -196,17 +196,19 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
         if (ctorStatus) {
             // ctor failed
             callDestructor<android::GraphicBuffer>(functions.destructor, gb);
-            std::cerr << "GraphicBuffer constructor failed, initCheck returned " << ctorStatus << std::endl;
+            __android_log_print(ANDROID_LOG_ERROR, "GraphicBuffer", "GraphicBuffer constructor failed, initCheck returned %d", ctorStatus);
         }
 
         // check object layout
-        if (base->magic != 0x5f626672u) // "_bfr"
-            std::cerr << "GraphicBuffer layout unexpected" << std::endl;
+        if (base->magic != 0x5f626672u) { // "_bfr"
+            __android_log_print(ANDROID_LOG_ERROR, "GraphicBuffer", "GraphicBuffer layout unexpected");
+        }
 
         // check object version
         const uint32_t expectedVersion = sizeof(void *) == 4 ? 96 : 168;
-        if (base->version != expectedVersion)
-            std::cerr << "GraphicBuffer version unexpected" << std::endl;
+        if (base->version != expectedVersion) {
+            __android_log_print(ANDROID_LOG_ERROR, "GraphicBuffer", "GraphicBuffer version unexpected");
+        }
 
         // reference count
         base->incRef(base);
@@ -215,7 +217,7 @@ GraphicBuffer::GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format
         impl = gb;
     } catch (...) {
         // freeing memory on error
-        std::cerr << "GraphicBuffer constructor failed" << std::endl;
+        __android_log_print(ANDROID_LOG_ERROR, "GraphicBuffer", "GraphicBuffer constructor failed");
         free(memory);
         throw;
     }

--- a/GraphicBuffer.h
+++ b/GraphicBuffer.h
@@ -1,8 +1,17 @@
+/**
+ * @file GraphicBuffer.h
+ * @brief This class implements the GraphicBuffer hack for
+ * Android API <= 25 replacing the missing HardwareBuffer
+ * functionality present in API >= 26
+ */
+
 #pragma once
 
 #include "DynamicLibrary.h"
 #include <cstdint>
 #include <cerrno>
+
+// Defining the required supplementary structures
 
 struct ANativeWindowBuffer;
 
@@ -91,10 +100,13 @@ struct GraphicBufferFunctions
     initCheckFunc					initCheck;
 };
 
+/** @class The GraphicBuffer wrapper */
 class GraphicBuffer
 {
 public:
-    // ui/GraphicBuffer.h, hardware/gralloc.h
+    /** @brief Usage types for the buffer
+     * @see ui/GraphicBuffer.h, hardware/gralloc.h
+     */
     enum {
         USAGE_SW_READ_NEVER		= 0x00000000,
         USAGE_SW_READ_RARELY	= 0x00000002,
@@ -118,12 +130,20 @@ public:
         USAGE_HW_MASK			= 0x00071F00,
     };
 
+    /**
+     * @brief GraphicBuffer constructor
+     * @param width Width of the buffer
+     * @param height Height of the buffer
+     * @param format An element from the PixelFormat enum
+     * @param usage An element from the usage enum in GraphicBuffer class (USAGE_*)
+     */
     GraphicBuffer(uint32_t width, uint32_t height, PixelFormat format, uint32_t usage);
     ~GraphicBuffer();
 
     status_t lock(uint32_t usage, void** vaddr);
     status_t unlock();
     ANativeWindowBuffer *getNativeBuffer() const;
+
     uint32_t getStride() const;
 
 private:

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ Use GraphicBuffer class in Android native code in your project, without compilin
 
 This repository is for API 25, and along with using the code, the app needs to be a system app. See details below.
 
-Moreover, this README provides an example of usage of the buffer to obtain a rendered texture image using simple and fast `memcpy()` calls, both for `GraphicBuffer` (API < 25) and `HardwareBuffer` (API > 25).
+Moreover, this README provides an example of usage of the buffer to obtain a rendered texture image using simple and fast `memcpy()` calls, both for `GraphicBuffer` (API <= 25) and `HardwareBuffer` (API > 25).
 
 Inspired by [tcuAndroidInternals.cpp](https://android.googlesource.com/platform/external/deqp/+/master/framework/platform/android/tcuAndroidInternals.cpp)
 
 # How to use
 
-The usage is exactly the same with `android::GraphicBuffer` or `HardwareBuffer` on API >= 26.
+The usage is exactly the same with `android::GraphicBuffer` on API <= 25 or `HardwareBuffer` on API >= 26.
 The example below shows a pseudo-code which renders something to a texture attached to a framebuffer and get the result using simple `memcpy()` calls.
 Examples for both API >= 26 (HardwareBuffer) and API < 26 (GraphicBuffer) are provided.
 If something doesn't work, it's worth checking if pointers are valid, if there are any errors from Android system and also checking return codes with `glGetError` if drawing issues occur.
 
-GraphicBuffer
+An example for API <= 25 using this repository, GraphicBuffer:
 ```c++
 // for EGL calls
 #define EGL_EGLEXT_PROTOTYPES
@@ -96,7 +96,7 @@ graphicBuf->unlock();
 ```
 
 Example for API >= 26. This repository is NOT needed, because there is an open alternative in NDK [1].
-The example does exactly the same.
+The example does exactly the same thing as the one above.
 ```c++
 // for EGL calls
 #define EGL_EGLEXT_PROTOTYPES
@@ -135,7 +135,7 @@ AHardwareBuffer* graphicBuf;
 AHardwareBuffer_allocate(&usage, &graphicBuf); // it's worth to check the return code
 
 // ACTUAL parameters of the AHardwareBuffer which it reports
-AHardwareBuffer_Desc usage;
+AHardwareBuffer_Desc usage1;
 
 // for stride, see below
 AHardwareBuffer_describe(graphicBuf, &usage1);
@@ -236,7 +236,7 @@ It will produce output similar to this:
 Find a constructor that is suitable for you. Try googling for source code of `GraphicBuffer.cpp` for your API, for example: https://android.googlesource.com/platform/frameworks/native/+/jb-dev/libs/ui/GraphicBuffer.cpp. Once you have identified the constructor signature you would like to use, find the name of it's symbol in
 
 ```
-# same as above by without -C
+# same as above but without -C
 $ /somewhere/android-ndk/find-it/arm-linux-androideabi-gcc-nm -D libui.so | grep GraphicBuffer | sort
 ```
 
@@ -248,5 +248,7 @@ For lower APIs (unclear which ones), the solution at https://github.com/fuyufjh/
 4. Debug the code using `print` statements showing error codes
 
 [1] https://developer.android.com/ndk/guides/stable_apis https://developer.android.com/reference/android/hardware/HardwareBuffer
+
 [2] https://developer.android.com/about/versions/nougat/android-7.0-changes
+
 [3] `libbacktrace.so libbase.so libbinder.so libc.so libc++.so libcutils.so libdl.so gralloc.exynos5.so libhardware.so libion.so liblog.so liblzma.so libm.so libsync.so libui.so libunwind.so libutils.so`, obtained by a simple recursive jupyter notebook using `!{readelf_bin} -d {file} | grep NEEDED`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is for API 25, and along with using the code, the app needs to b
 
 Moreover, this README provides an example of usage of the buffer to obtain a rendered texture image using simple and fast `memcpy()` calls, both for `GraphicBuffer` (API <= 25) and `HardwareBuffer` (API > 25).
 
-The original implementation by @fuyufjh (branch `original` in this repo) is for API <= 23, and this one (branch `master`) is for API 25 (not clear which one works on API 24 but it definitely needs the system app trick [1]).
+The original implementation by `fuyufjh` (branch `original` in this repo) is for API <= 23, and this one (branch `master`) is for API 25 (not clear which one works on API 24 but it definitely needs the system app trick [1]).
 
 Inspired by [tcuAndroidInternals.cpp](https://android.googlesource.com/platform/external/deqp/+/master/framework/platform/android/tcuAndroidInternals.cpp)
 

--- a/README.md
+++ b/README.md
@@ -2,40 +2,251 @@
 
 Use GraphicBuffer class in Android native code in your project, without compiling with Android source code.
 
+This repository is for API 25, and along with using the code, the app needs to be a system app. See details below.
+
+Moreover, this README provides an example of usage of the buffer to obtain a rendered texture image using simple and fast `memcpy()` calls, both for `GraphicBuffer` (API < 25) and `HardwareBuffer` (API > 25).
+
 Inspired by [tcuAndroidInternals.cpp](https://android.googlesource.com/platform/external/deqp/+/master/framework/platform/android/tcuAndroidInternals.cpp)
 
 # How to use
 
-The usage is exactly the same with `android::GraphicBuffer`
+The usage is exactly the same with `android::GraphicBuffer` or `HardwareBuffer` on API >= 26.
+The example below shows a pseudo-code which renders something to a texture attached to a framebuffer and get the result using simple `memcpy()` calls.
+Examples for both API >= 26 (HardwareBuffer) and API < 26 (GraphicBuffer) are provided.
+If something doesn't work, it's worth checking if pointers are valid, if there are any errors from Android system and also checking return codes with `glGetError` if drawing issues occur.
 
+GraphicBuffer
 ```c++
-#include "GraphicBuffer.h"
-```
+// for EGL calls
+#define EGL_EGLEXT_PROTOTYPES
+#include "EGL/egl.h"
+#include "EGL/eglext.h"
+#include "GLES/gl.h"
+#define GL_GLEXT_PROTOTYPES
+#include "GLES/glext.h"
 
-Intialize
+// for API 25 use this repo, for API <23 see the https://github.com/fuyufjh/GraphicBuffer
+// Also add -lEGL at link stage
+#include "GraphicBuffer.h" 
 
-```c++
-int usage = GraphicBuffer::USAGE_HW_TEXTURE | GraphicBuffer::USAGE_SW_READ_OFTEN | GraphicBuffer::USAGE_SW_WRITE_RARELY;
-auto graphicBuf = std::make_unique<GraphicBuffer>(width, height, PIXEL_FORMAT_RGBA_8888, usage);
-```
+// bind FBO (create FBO my_handle first!)
+glBindFramebuffer(GL_FRAMEBUFFER, my_handle);
 
-Get ANativeWindowBuffer (or EGLClientBuffer)
+// attach texture to FBO (create texture my_texture first!)
+glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, my_texture, 0);
 
-```c++
+// usage for the GraphicBuffer
+int usage = GraphicBuffer::USAGE_HW_RENDER | GraphicBuffer::USAGE_SW_READ_OFTEN | GraphicBuffer::USAGE_SW_WRITE_NEVER;
+
+// create GraphicBuffer
+GraphicBuffer* graphicBuf = new GraphicBuffer(width, height, PIXEL_FORMAT_RGBA_8888, usage);
+
+// get the native buffer
 auto clientBuf = (EGLClientBuffer) graphicBuf->getNativeBuffer();
-```
 
-Get content image:
+// obtaining the EGL display
+EGLDisplay disp = eglGetDisplay(EGL_DEFAULT_DISPLAY); EGL_CHECK_ERROR();
 
-```c++
+// specifying the image attributes
+EGLint eglImageAttributes[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE};
+
+// creating an EGL image
+EGLImageKHR imageEGL = eglCreateImageKHR(disp, EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuf, eglImageAttributes);
+
+// Doing some OpenGL rendering like glDrawArrays
+// Shaders also work, need `#extension GL_OES_EGL_image_external : require`
+// Now the result is inside the FBO my_handle
+
+// binding the OUTPUT texture
+glBindTexture(GL_TEXTURE_2D, my_texture);
+
+// attaching an EGLImage to OUTPUT texture
+glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, imageEGL);
+
+// Obtaining the content image:
+
+// pointer for reading and writing texture data
 void *readPtr, *writePtr;
+
+// locking the buffer
 graphicBuf->lock(GraphicBuffer::USAGE_SW_READ_OFTEN, &readPtr);
-writePtr = image.data;
+
+// setting the write pointer
+writePtr = <set to a valid memory area, like malloc(_YOUR_SIZE_)>
+
+// obtaining the stride (for me it was always = width)
 int stride = graphicBuf->getStride();
+
+// loop over texture rows
 for (int row = 0; row < height; row++) {
+    // copying, 4 = 4 channels RGBA because of the format above
     memcpy(writePtr, readPtr, width * 4);
+
+    // adding stride * 4 to read pointer
     readPtr = (void *)(int(readPtr) + stride * 4);
+
+    // adding width * 4 to write pointer
     writePtr = (void *)(int(writePtr) + width * 4);
 }
+
+// NOW data is in writePtr memory
+
+// unlocking the buffer
 graphicBuf->unlock();
 ```
+
+Example for API >= 26. This repository is NOT needed, because there is an open alternative in NDK [1].
+The example does exactly the same.
+```c++
+// for EGL calls
+#define EGL_EGLEXT_PROTOTYPES
+#include "EGL/egl.h"
+#include "EGL/eglext.h"
+#include "GLES/gl.h"
+#define GL_GLEXT_PROTOTYPES
+#include "GLES/glext.h"
+
+// for API >= 26
+// Also add -lEGL -lnativewindow -lGLESv3 at link stage
+#include "android/hardware_buffer.h"
+
+// bind FBO (create FBO my_handle first!)
+glBindFramebuffer(GL_FRAMEBUFFER, my_handle);
+
+// attach texture to FBO (create texture my_texture first!)
+glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, my_texture, 0);
+
+// OUR parameters that we will set and give it to AHardwareBuffer
+AHardwareBuffer_Desc usage;
+
+// filling in the usage for HardwareBuffer
+usage.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+usage.height = outputHeight;
+usage.width = outputWidth;
+usage.layers = 1;
+usage.rfu0 = 0;
+usage.rfu1 = 0;
+usage.stride = 10;
+usage.usage = AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN | AHARDWAREBUFFER_USAGE_CPU_WRITE_NEVER
+        | AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT;
+
+// create GraphicBuffer
+AHardwareBuffer* graphicBuf;
+AHardwareBuffer_allocate(&usage, &graphicBuf); // it's worth to check the return code
+
+// ACTUAL parameters of the AHardwareBuffer which it reports
+AHardwareBuffer_Desc usage;
+
+// for stride, see below
+AHardwareBuffer_describe(graphicBuf, &usage1);
+
+// get the native buffer
+EGLClientBuffer clientBuf = eglGetNativeClientBufferANDROID(graphicBuf);
+
+// obtaining the EGL display
+EGLDisplay disp = eglGetDisplay(EGL_DEFAULT_DISPLAY); EGL_CHECK_ERROR();
+
+// specifying the image attributes
+EGLint eglImageAttributes[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE};
+
+// creating an EGL image
+EGLImageKHR imageEGL = eglCreateImageKHR(disp, EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuf, eglImageAttributes);
+
+// Doing some OpenGL rendering like glDrawArrays
+// Shaders also work, need `#extension GL_OES_EGL_image_external_essl3 : require`
+// Now the result is inside the FBO my_handle
+
+// binding the OUTPUT texture
+gl->glBindTexture(GL_TEXTURE_2D, my_texture);
+
+// attaching an EGLImage to OUTPUT texture
+glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, imageEGL);
+
+// Obtaining the content image:
+
+// pointer for reading and writing texture data
+void *readPtr, *writePtr;
+
+// locking the buffer
+AHardwareBuffer_lock(graphicBuf, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, (void**) &readPtr); // worth checking return code
+
+// setting the write pointer
+writePtr = <set to a valid memory area, like malloc(_YOUR_SIZE_)>
+
+// obtaining the stride (for me it was always = width)
+int stride = usage1.stride;
+
+// loop over texture rows
+for (int row = 0; row < height; row++) {
+    // copying, 4 = 4 channels RGBA because of the format above
+    memcpy(writePtr, readPtr, width * 4);
+
+    // adding stride * 4 to read pointer
+    readPtr = (void *)(int(readPtr) + stride * 4);
+
+    // adding width * 4 to write pointer
+    writePtr = (void *)(int(writePtr) + width * 4);
+}
+
+// NOW data is in writePtr memory
+
+// unlocking the buffer
+AHardwareBuffer_unlock(graphicBuf, nullptr); // worth checking return code
+```
+
+# How to access private libraries on API 25
+On API 26, there is a public `HardwareBuffer` [1] option which replaces GraphicBuffer hacks. On API < 24 the hack from the original repo worked because the access to private libraries such as `libui.so` was allowed.
+
+It's still allowed [2] in 25, however, `libui.so` also requires `gralloc.exynos5.so` (see full list of its dependencies [3]) which is **not allowed to use on API 25**. The app is killed when trying to dlopen `libui.so` (on `new GraphicBuffer()`).
+
+It seems that there is a solution for API < 24 and for API >= 26, but on 24 and 25 it seems that it's impossible to use any kind of GraphicBuffer-like access.
+
+The solution for API 25, along with using code from this repository, is to make your application a system application.
+It requires root privileges.
+The process is described in https://stackoverflow.com/questions/24641604/qt-application-as-system-app-on-android for Qt-based apps.
+
+# How to tweak API
+
+The original version in https://github.com/fuyufjh/GraphicBuffer/blob/fa346e1f6266a717758d32aee9c75c85da8a7263/GraphicBuffer.cpp uses the `_ZN7android13GraphicBufferC1Ejjij` constructor symbol, which was replaced by `_ZN7android13GraphicBufferC1EjjijNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE` in API 25 (a std::string argument added at the end). This repository works for the API 25 and the original one works for the lower versions.
+
+Since I'm not sure if any other APIs have different constructors, below you can find directions on how to tweak the code for your API.
+
+1. Copy your file `/system/lib/libui.so` from your Android device to your PC. This is the file that contains symbol names for `GraphicBuffer`.
+2. Using Android NDK's `nm` for your architecture, run:
+```
+$ /somewhere/android-ndk/find-it/arm-linux-androideabi-gcc-nm -C -D libui.so | grep GraphicBuffer | sort
+```
+
+It will produce output similar to this:
+
+```
+<other stuff>
+0000de2c T android::GraphicBuffer::GraphicBuffer()
+0000de2c T android::GraphicBuffer::GraphicBuffer()
+0000dec8 T android::GraphicBuffer::GraphicBuffer(unsigned int, unsigned int, int, unsigned int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)
+0000dec8 T android::GraphicBuffer::GraphicBuffer(unsigned int, unsigned int, int, unsigned int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)
+0000dfd8 T android::GraphicBuffer::initSize(unsigned int, unsigned int, int, unsigned int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)
+0000e074 T android::GraphicBuffer::GraphicBuffer(unsigned int, unsigned int, int, unsigned int, unsigned int, native_handle*, bool)
+0000e074 T android::GraphicBuffer::GraphicBuffer(unsigned int, unsigned int, int, unsigned int, unsigned int, native_handle*, bool)
+0000e120 T android::GraphicBuffer::GraphicBuffer(ANativeWindowBuffer*, bool)
+0000e120 T android::GraphicBuffer::GraphicBuffer(ANativeWindowBuffer*, bool)
+<other stuff>
+```
+
+Find a constructor that is suitable for you. Try googling for source code of `GraphicBuffer.cpp` for your API, for example: https://android.googlesource.com/platform/frameworks/native/+/jb-dev/libs/ui/GraphicBuffer.cpp. Once you have identified the constructor signature you would like to use, find the name of it's symbol in
+
+```
+# same as above by without -C
+$ /somewhere/android-ndk/find-it/arm-linux-androideabi-gcc-nm -D libui.so | grep GraphicBuffer | sort
+```
+
+Copy the name of the symbol, for example: `_ZN7android13GraphicBufferC1EjjijNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE`. It corresponds 1-to-1 to the human-readable signature. For my API 25 the difference from https://github.com/fuyufjh/GraphicBuffer was that there was an `std::string` argument added.
+
+For lower APIs (unclear which ones), the solution at https://github.com/fuyufjh/GraphicBuffer uses `_ZN7android13GraphicBufferC1Ejjij` which is absent in API 25.
+
+3. Having identified your constructor, change the code in `GraphicBuffer.cpp` appropriately. For API 25 a `std::string` argument was added, it has to be passed by reference and the variable with the string should remain after function call ends (I just made it `static`).
+4. Debug the code using `print` statements showing error codes
+
+[1] https://developer.android.com/ndk/guides/stable_apis https://developer.android.com/reference/android/hardware/HardwareBuffer
+[2] https://developer.android.com/about/versions/nougat/android-7.0-changes
+[3] `libbacktrace.so libbase.so libbinder.so libc.so libc++.so libcutils.so libdl.so gralloc.exynos5.so libhardware.so libion.so liblog.so liblzma.so libm.so libsync.so libui.so libunwind.so libutils.so`, obtained by a simple recursive jupyter notebook using `!{readelf_bin} -d {file} | grep NEEDED`

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Use GraphicBuffer class in Android native code in your project, without compiling with Android source code.
 
-This repository is for API 25, and along with using the code, the app needs to be a system app. See details below.
+This repository is for APIs 23-27. API 23 is supported without additional tricks, APIs 24-25 need making your application a system application.
 
-Moreover, this README provides an example of usage of the buffer to obtain a rendered texture image using simple and fast `memcpy()` calls, both for `GraphicBuffer` (API <= 25) and `HardwareBuffer` (API > 25).
+APIs 26 and 27 do not need code from this repository since a more convenient alternative is available: `HardwareBuffer`.
 
-The original implementation by `fuyufjh` (branch `original` in this repo) is for API <= 23, and this one (branch `master`) is for API 25 (not clear which one works on API 24 but it definitely needs the system app trick [1]).
+Moreover, this README provides an example of usage of the buffer to obtain a rendered texture image using simple and fast `memcpy()` calls, both for `GraphicBuffer` (API <= 23) and `HardwareBuffer` (API >= 26).
 
 Inspired by [tcuAndroidInternals.cpp](https://android.googlesource.com/platform/external/deqp/+/master/framework/platform/android/tcuAndroidInternals.cpp)
 
@@ -27,7 +27,7 @@ An example for API <= 25 using this repository, GraphicBuffer:
 #define GL_GLEXT_PROTOTYPES
 #include "GLES/glext.h"
 
-// for API 25 use this repo, for API <= 23 see the https://github.com/fuyufjh/GraphicBuffer
+// Use code from this repository. Note that define __ANDROID_API__ must be set properly for it to work
 // Also add -lEGL at link stage
 #include "GraphicBuffer.h" 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Inspired by [tcuAndroidInternals.cpp](https://android.googlesource.com/platform/
 The usage is exactly the same with `android::GraphicBuffer` on API <= 25 or `HardwareBuffer` on API >= 26.
 The example below shows a pseudo-code which renders something to a texture attached to a framebuffer and get the result using simple `memcpy()` calls.
 Examples for both API >= 26 (HardwareBuffer) and API < 26 (GraphicBuffer) are provided.
-If something doesn't work, it's worth checking if pointers are valid, if there are any errors from Android system and also checking return codes with `glGetError` if drawing issues occur.
+If something doesn't work, it's worth checking if pointers are valid, if `eglGetError()` shows no issues, if there are any errors from Android system and also checking return codes with `glGetError()` if drawing issues occur.
 
 An example for API <= 25 using this repository, GraphicBuffer:
 ```c++

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ GraphicBuffer* graphicBuf = new GraphicBuffer(width, height, PIXEL_FORMAT_RGBA_8
 auto clientBuf = (EGLClientBuffer) graphicBuf->getNativeBuffer();
 
 // obtaining the EGL display
-EGLDisplay disp = eglGetDisplay(EGL_DEFAULT_DISPLAY); EGL_CHECK_ERROR();
+EGLDisplay disp = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 
 // specifying the image attributes
 EGLint eglImageAttributes[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE};
@@ -146,7 +146,7 @@ AHardwareBuffer_describe(graphicBuf, &usage1);
 EGLClientBuffer clientBuf = eglGetNativeClientBufferANDROID(graphicBuf);
 
 // obtaining the EGL display
-EGLDisplay disp = eglGetDisplay(EGL_DEFAULT_DISPLAY); EGL_CHECK_ERROR();
+EGLDisplay disp = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 
 // specifying the image attributes
 EGLint eglImageAttributes[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE};

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository is for API 25, and along with using the code, the app needs to b
 
 Moreover, this README provides an example of usage of the buffer to obtain a rendered texture image using simple and fast `memcpy()` calls, both for `GraphicBuffer` (API <= 25) and `HardwareBuffer` (API > 25).
 
+The original implementation by @fuyufjh (branch `original` in this repo) is for API <= 23, and this one (branch `master`) is for API 25 (not clear which one works on API 24 but it definitely needs the system app trick [1]).
+
 Inspired by [tcuAndroidInternals.cpp](https://android.googlesource.com/platform/external/deqp/+/master/framework/platform/android/tcuAndroidInternals.cpp)
 
 # How to use
@@ -25,7 +27,7 @@ An example for API <= 25 using this repository, GraphicBuffer:
 #define GL_GLEXT_PROTOTYPES
 #include "GLES/glext.h"
 
-// for API 25 use this repo, for API <23 see the https://github.com/fuyufjh/GraphicBuffer
+// for API 25 use this repo, for API <= 23 see the https://github.com/fuyufjh/GraphicBuffer
 // Also add -lEGL at link stage
 #include "GraphicBuffer.h" 
 
@@ -195,11 +197,11 @@ AHardwareBuffer_unlock(graphicBuf, nullptr); // worth checking return code
 ```
 
 # How to access private libraries on API 25
-On API 26, there is a public `HardwareBuffer` [1] option which replaces GraphicBuffer hacks. On API < 24 the hack from the original repo worked because the access to private libraries such as `libui.so` was allowed.
+On API 26, there is a public `HardwareBuffer` [1] option which replaces GraphicBuffer hacks. On API <= 23 the hack from the original repo worked because the access to private libraries such as `libui.so` was allowed.
 
 It's still allowed [2] in 25, however, `libui.so` also requires `gralloc.exynos5.so` (see full list of its dependencies [3]) which is **not allowed to use on API 25**. The app is killed when trying to dlopen `libui.so` (on `new GraphicBuffer()`).
 
-It seems that there is a solution for API < 24 and for API >= 26, but on 24 and 25 it seems that it's impossible to use any kind of GraphicBuffer-like access.
+It seems that there is a solution for API <= 23 and for API >= 26, but on 24 and 25 it seems that it's impossible to use any kind of GraphicBuffer-like access.
 
 The solution for API 25, along with using code from this repository, is to make your application a system application.
 It requires root privileges.


### PR DESCRIPTION
This PR fixes #5 and also adds an example for #7 .

- APIs 23 and 24-25 use different constructors, the selection is done via the `__ANDROID_API__` define.
- `cerr` is replaced with android log
- Tested on API 23, 24, 26, should work on all APIs 23-27. However, would be nice if someone could test it also
- On API 26 and 27 the code is not required, see README for example usage
- Added comments in `.cpp` files
- Added info on how to tailor library to different APIs (see README)